### PR TITLE
Disable git2 default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ default-target = "x86_64-unknown-linux-gnu"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-git2 = "0.13"
+[dependencies.git2]
+version = "0.13"
+default-features = false


### PR DESCRIPTION
At the moment this crate seems to depend on openssl due to git2's default features which include ssh and https. Since those features aren't required I'd propose to disable them.